### PR TITLE
CDD-2109: schema changes required to inventoryLinkingCommonTypes.xsd …

### DIFF
--- a/public/api/conf/1.0/examples/consolidationRequest.xml
+++ b/public/api/conf/1.0/examples/consolidationRequest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inv:inventoryLinkingConsolidationRequest xmlns:inv="http://gov.uk/customs/inventoryLinking/v1">
   <inv:messageCode>CST</inv:messageCode>
+  <inv:transactionType>Associate</inv:transactionType>
   <inv:masterUCR>GB/MMMM-00000</inv:masterUCR>
   <inv:ucrBlock>
     <inv:ucr>GB/AAAA-12345</inv:ucr>

--- a/public/api/conf/1.0/schemas/exports/common/inventoryLinkingCommonTypes.xsd
+++ b/public/api/conf/1.0/schemas/exports/common/inventoryLinkingCommonTypes.xsd
@@ -115,7 +115,7 @@
 			<xs:element name="errorCode" minOccurs="1">
 			<xs:simpleType>
 					<xs:restriction base="xs:string">
-						<xs:maxLength value="2" />
+						<xs:maxLength value="1024" />
 						<xs:minLength value="1" />
 					</xs:restriction>
 				</xs:simpleType>

--- a/public/api/conf/1.0/schemas/exports/common/inventoryLinkingCore.xsd
+++ b/public/api/conf/1.0/schemas/exports/common/inventoryLinkingCore.xsd
@@ -66,6 +66,7 @@
 	    </xs:annotation>
         <xs:sequence>
             <xs:element name="messageCode" type="messageCodeConsolidation" minOccurs="1" />
+            <xs:element name="transactionType" type="consolidationTransaction" minOccurs="1" />
             <xs:element name="masterUCR" type="ucr" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>Mandatory for a CST message, if not supplied in an EAC message the current association is removed</xs:documentation>
@@ -107,7 +108,7 @@
             <!-- Traders movement reference as additional return reference, if appropriate -->
             <xs:element name="movementReference" type="movementReference" minOccurs="0" maxOccurs="1" nillable="true" />
             <!-- Error block only included if action code is 3 -->
-            <xs:element name="error" type="errorBlock" minOccurs="0" maxOccurs="1" />
+            <xs:element name="error" type="errorBlock" minOccurs="0" maxOccurs="unbounded" />
         </xs:sequence>
 	</xs:complexType>
 

--- a/test/util/XMLTestData.scala
+++ b/test/util/XMLTestData.scala
@@ -68,6 +68,7 @@ object XMLTestData {
   val ValidInventoryLinkingConsolidationRequestXML: Elem =
     <inventoryLinkingConsolidationRequest xmlns="http://gov.uk/customs/inventoryLinking/v1">
       <messageCode>EAC</messageCode>
+      <transactionType>Associate</transactionType>
       <masterUCR>GB/AAAA-00000</masterUCR>
       <ucrBlock>
         <ucr>GB/BBBB-00000</ucr>


### PR DESCRIPTION
… & inventoryLinkingCore.xsd:

- errorCode is in inventoryLinkingCommonTypes.xsd and maxLength is changed from 2 to 1024
- errorBlock is in inventoryLinkingCore.xsd and maxOccurs changed from 1 to unbounded
- new mandatory element "TransactionType"  in inventoryLinkingCore.xsd