### PR TITLE
DCWL-3670: Dependency upgrade to fix the jackson-core vulnerability

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object AppDependencies {
 
   val playVersion = "play-30"
-  val bootstrap = "9.11.0"
+  val bootstrap = "9.18.0"
 
   val compile = Seq(
     "org.typelevel"      %% "cats-core"                       % "2.10.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 resolvers += Resolver.jcenterRepo
 
 addSbtPlugin("com.github.sbt"    %  "sbt-release"           % "1.0.15")
-addSbtPlugin("org.playframework" %  "sbt-plugin"            % "3.0.6")
+addSbtPlugin("org.playframework" %  "sbt-plugin"            % "3.0.8")
 addSbtPlugin("uk.gov.hmrc"       %  "sbt-distributables"    % "2.6.0")
 addSbtPlugin("net.virtual-void"  %  "sbt-dependency-graph"  % "0.10.0-RC1")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"          % "2.3.1")


### PR DESCRIPTION
Please ensure we are following our Ways of Working for Pull Requests: https://confluence.tools.tax.service.gov.uk/display/BTL/Ways+of+Working+for+Pull+Requests